### PR TITLE
Fix #24: NPE on empty task list

### DIFF
--- a/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporter.groovy
+++ b/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporter.groovy
@@ -15,6 +15,8 @@ class SummaryReporter extends AbstractBuildTimeTrackerReporter {
 
     @Override
     def run(List<Timing> timings) {
+        if (timings.size() == 0) return
+
         def threshold = getOption("threshold", "50").toInteger()
 
         if (getOption("ordered", "false").toBoolean()) {

--- a/src/test/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporterTest.groovy
+++ b/src/test/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporterTest.groovy
@@ -114,4 +114,14 @@ class SummaryReporterTest {
         assertTrue lines[2].contains("task3")
         assertTrue lines[3].contains("task2")
     }
+
+    @Test
+    void testEmptyTaskList() {
+        def mockLogger = new MockFor(Logger)
+        mockLogger.demand.quiet(0) {}
+
+        def reporter = new SummaryReporter([:], mockLogger.proxyInstance())
+        reporter.run([
+        ])
+    }
 }


### PR DESCRIPTION
I guess there's not really a point in executing the reporter at all if the task list is empty, right? // @daithiocrualaoich 
