### PR TITLE
Fix -echo problems again

### DIFF
--- a/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporter.groovy
+++ b/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporter.groovy
@@ -58,7 +58,7 @@ class SummaryReporter extends AbstractBuildTimeTrackerReporter {
         def total = timings.sum { t -> t.ms }
         def longestTaskName = timings.collect { it.path.length() }.max()
         def longestTiming = timings*.ms.max()
-        def maxColumns = TerminalFactory.get().width
+        def maxColumns = TerminalInstance.get().width
         if (maxColumns == null) maxColumns = 80
 
         def maxBarWidth

--- a/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/TerminalInstance.groovy
+++ b/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/TerminalInstance.groovy
@@ -1,0 +1,15 @@
+package net.rdrei.android.buildtimetracker.reporters
+
+import jline.Terminal
+import jline.TerminalFactory
+
+/**
+ * Singleton wrapper around {@link jline.TerminalFactory} to work around jline2#163
+ */
+class TerminalInstance {
+    private static Terminal sInstance = TerminalFactory.get()
+
+    public static Terminal get() {
+        return sInstance
+    }
+}


### PR DESCRIPTION
Workaround for jline/jline2#163, make sure that only ever one instance of
Terminal is created to avoid introducing a race condition when the new instance
tries to restore an intermediate state at the end of its lifecycle.

@daithiocrualaoich Could you perhaps give this a try?
