### PR TITLE
Add the ability to disable the shortening of long task names

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -114,6 +114,7 @@ build. It has the following options:
   displaying a bar chart of the relative times spent on each task.
 * `successOutput`: (default: "true") Redisplay build success or failure message
   so you don't miss it if the summary output is long.
+* `shortenTaskNames`: (default: "true") Shortens long tasks names.
 
 _Note_ This plugin only measures the task times that constitute a build.
 Specifically, it does not measure the time in configuration at the start

--- a/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporter.groovy
+++ b/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporter.groovy
@@ -11,12 +11,14 @@ class SummaryReporter extends AbstractBuildTimeTrackerReporter {
 
     String barStyle
     boolean successOutput
+    boolean shortenTaskNames
 
     SummaryReporter(Map<String, String> options, Logger logger) {
         super(options, logger)
 
         barStyle = getOption("barstyle", "unicode")
         successOutput = Boolean.parseBoolean(getOption("successOutput", "true"))
+        shortenTaskNames = Boolean.parseBoolean(getOption("shortenTaskNames", "true"))
     }
 
     @Override
@@ -67,7 +69,7 @@ class SummaryReporter extends AbstractBuildTimeTrackerReporter {
             if (timing.ms >= threshold) {
                 logger.info(sprintf("%s %s (%s)",
                         createBar(timing.ms / total, timing.ms / longestTiming, maxBarWidth),
-                        shortenTaskName(timing.path, maxBarWidth),
+                        shortenTaskNames ? shortenTaskName(timing.path, maxBarWidth) : timing.path,
                         FormattingUtils.formatDuration(timing.ms)))
             }
         }

--- a/src/test/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporterTest.groovy
+++ b/src/test/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporterTest.groovy
@@ -104,6 +104,34 @@ class SummaryReporterTest {
     }
 
     @Test
+    void testOutputIncludesShortenedLongTaskName() {
+        def mockLogger = new MockFor(Logger)
+        def lines = []
+        mockLogger.demand.info(2) { l -> lines << l }
+
+        def reporter = new SummaryReporter([:], mockLogger.proxyInstance())
+        reporter.run([
+                new Timing(300, "thisIsAReallyLongNameJustForTask1", true, false, true)
+        ])
+
+        assert lines[1].contains("thisIsAReally…JustForTask1")
+    }
+
+    @Test
+    void testOutputIncludesLongTaskName() {
+        def mockLogger = new MockFor(Logger)
+        def lines = []
+        mockLogger.demand.info(2) { l -> lines << l }
+
+        def reporter = new SummaryReporter([shortenTaskNames: false], mockLogger.proxyInstance())
+        reporter.run([
+                new Timing(300, "thisIsAReallyLongNameJustForTask1", true, false, true)
+        ])
+
+        assert lines[1].contains("thisIsAReallyLongNameJustForTask1")
+    }
+
+    @Test
     void testEmptyTaskList() {
         def mockLogger = new MockFor(Logger)
         mockLogger.demand.info(0) {}


### PR DESCRIPTION
Wasn't sure what the best name for this new option should be so feel free to rename things/improve the JavaDoc!

Fixes #58 
