### PR TITLE
Fix TerminalInfo test non-determinism

### DIFF
--- a/src/test/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporterTest.groovy
+++ b/src/test/groovy/net/rdrei/android/buildtimetracker/reporters/SummaryReporterTest.groovy
@@ -106,13 +106,17 @@ class SummaryReporterTest {
     @Test
     void testOutputIncludesShortenedLongTaskName() {
         def mockLogger = new MockFor(Logger)
+        def mockTerminal = new MockFor(TerminalInfo)
         def lines = []
         mockLogger.demand.info(2) { l -> lines << l }
+        mockTerminal.demand.getWidth(1) { 80 }
 
-        def reporter = new SummaryReporter([:], mockLogger.proxyInstance())
-        reporter.run([
-                new Timing(300, "thisIsAReallyLongNameJustForTask1", true, false, true)
-        ])
+        mockTerminal.use {
+            def reporter = new SummaryReporter([:], mockLogger.proxyInstance())
+            reporter.run([
+                    new Timing(300, "thisIsAReallyLongNameJustForTask1", true, false, true)
+            ])
+        }
 
         assert lines[1].contains("thisIsAReally…JustForTask1")
     }
@@ -120,13 +124,17 @@ class SummaryReporterTest {
     @Test
     void testOutputIncludesLongTaskName() {
         def mockLogger = new MockFor(Logger)
+        def mockTerminal = new MockFor(TerminalInfo)
         def lines = []
         mockLogger.demand.info(2) { l -> lines << l }
+        mockTerminal.demand.getWidth(1) { 80 }
 
-        def reporter = new SummaryReporter([shortenTaskNames: false], mockLogger.proxyInstance())
-        reporter.run([
-                new Timing(300, "thisIsAReallyLongNameJustForTask1", true, false, true)
-        ])
+        mockTerminal.use {
+            def reporter = new SummaryReporter([shortenTaskNames: false], mockLogger.proxyInstance())
+            reporter.run([
+                    new Timing(300, "thisIsAReallyLongNameJustForTask1", true, false, true)
+            ])
+        }
 
         assert lines[1].contains("thisIsAReallyLongNameJustForTask1")
     }


### PR DESCRIPTION
Still not perfect, I'd rather pass in proper instances via DI than mock
them globally like this. But this should do for now.

Fixes #68

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/passy/build-time-tracker-plugin/69)
<!-- Reviewable:end -->
