### PR TITLE
Add JDK 1.7 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ buildtimetracker {
   }
 }
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 dependencies {
   repositories {
     mavenCentral()


### PR DESCRIPTION
https://github.com/passy/build-time-tracker-plugin/issues/91

@passy I think we should be able to achieve this straight away using the compatibility attributes provided by gradle.